### PR TITLE
[WIP] 複数トレードの実装

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     compileOnly("net.okocraft.box:box-stick-feature:5.3.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
+    testRuntimeOnly("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 

--- a/src/main/java/net/okocraft/boxtradestick/MerchantRecipesGUI.java
+++ b/src/main/java/net/okocraft/boxtradestick/MerchantRecipesGUI.java
@@ -239,8 +239,8 @@ public class MerchantRecipesGUI implements InventoryHolder {
         } else {
 
             trader.sendActionBar(Translatables.MULTIPLE_RESULT_TIMES.apply(
-                    succeeded.length,
-                    Arrays.stream(succeeded).mapToInt(TradeResult::getCount).sum()
+                    Arrays.stream(succeeded).mapToInt(TradeResult::getCount).sum(),
+                    succeeded.length
             ));
         }
         return succeeded.length;

--- a/src/main/java/net/okocraft/boxtradestick/MerchantRecipesGUI.java
+++ b/src/main/java/net/okocraft/boxtradestick/MerchantRecipesGUI.java
@@ -21,7 +21,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantRecipe;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,14 +35,20 @@ public class MerchantRecipesGUI implements InventoryHolder {
     private final Inventory inventory;
 
     private final Player trader;
-    private final Merchant merchant;
+    private final AbstractVillager villager;
+    private final TradeStickData data;
 
-    public MerchantRecipesGUI(Player trader, Merchant merchant) {
-        this.inventory = Bukkit.createInventory(this, 54, Translatables.GUI_TITLE.apply(merchant));
+    public MerchantRecipesGUI(Player trader, AbstractVillager villager) {
+        this.inventory = Bukkit.createInventory(this, 54, Translatables.GUI_TITLE.apply(villager));
         this.trader = trader;
-        this.merchant = merchant;
+        this.villager = villager;
+        this.data = TradeStickData.loadFrom(villager);
 
         initialize();
+    }
+
+    public static boolean canTradeByStick(@NotNull AbstractVillager villager) {
+        return villager.getRecipeCount() < TradeStickData.MAXIMUM_INDEX;
     }
 
     public static boolean isGUI(Inventory topInventory) {
@@ -58,8 +63,8 @@ public class MerchantRecipesGUI implements InventoryHolder {
         }
     }
 
-    public Merchant getMerchant() {
-        return this.merchant;
+    public AbstractVillager getMerchant() {
+        return this.villager;
     }
 
     @Override
@@ -68,7 +73,7 @@ public class MerchantRecipesGUI implements InventoryHolder {
     }
 
     public int getMaxScroll() {
-        return Math.max(0, merchant.getRecipeCount() - 6);
+        return Math.max(0, villager.getRecipeCount() - 6);
     }
 
     public void scrollDown() {
@@ -88,7 +93,7 @@ public class MerchantRecipesGUI implements InventoryHolder {
     public void updateTradeItem(int row) {
         int recipeIndex = row + getScroll();
 
-        if (recipeIndex == getCurrentSelected()) {
+        if (data.isSelected(trader.getUniqueId(), recipeIndex)) {
             inventory.setItem(row * 9, ItemUtil.create(
                     trader.locale(),
                     Material.LIME_WOOL,
@@ -104,7 +109,7 @@ public class MerchantRecipesGUI implements InventoryHolder {
             ));
         }
 
-        MerchantRecipe recipe = merchant.getRecipe(recipeIndex);
+        MerchantRecipe recipe = villager.getRecipe(recipeIndex);
         List<ItemStack> ingredients = new ArrayList<>(recipe.getIngredients());
         for (int i = 0; i < ingredients.size(); i++) {
             ItemStack originalIngredient = ingredients.get(i);
@@ -158,7 +163,7 @@ public class MerchantRecipesGUI implements InventoryHolder {
     }
 
     public void update() {
-        for (int row = 0; row < Math.min(merchant.getRecipeCount(), 6); row++) {
+        for (int row = 0; row < Math.min(villager.getRecipeCount(), 6); row++) {
             updateTradeItem(row);
         }
     }
@@ -182,28 +187,25 @@ public class MerchantRecipesGUI implements InventoryHolder {
         int recipeIndex = row + getScroll();
 
         if (column == 0) {
-            if (recipeIndex < merchant.getRecipeCount()) {
-                setCurrentSelected(recipeIndex != getCurrentSelected() ? recipeIndex : -1);
+            if (recipeIndex < villager.getRecipeCount()) {
+                data.toggleOfferSelection(trader.getUniqueId(), recipeIndex);
+                data.saveTo(villager);
             }
         } else if (column == 5) {
             boolean tradeSuccess = trade(recipeIndex);
 
-            if (merchant instanceof AbstractVillager villager) {
-                if (tradeSuccess) {
-                    trader.playSound(villager, Sound.ENTITY_VILLAGER_TRADE, 1, 1);
-                } else {
-                    trader.playSound(villager, Sound.ENTITY_VILLAGER_NO, 1, 1);
-                }
+            if (tradeSuccess) {
+                trader.playSound(villager, Sound.ENTITY_VILLAGER_TRADE, 1, 1);
+            } else {
+                trader.playSound(villager, Sound.ENTITY_VILLAGER_NO, 1, 1);
             }
         } else if (column == 6) {
             boolean tradeSuccess = tradeForMaxUses(recipeIndex) > 0;
 
-            if (merchant instanceof AbstractVillager villager) {
-                if (tradeSuccess) {
-                    trader.playSound(villager, Sound.ENTITY_VILLAGER_TRADE, 1, 1);
-                } else {
-                    trader.playSound(villager, Sound.ENTITY_VILLAGER_NO, 1, 1);
-                }
+            if (tradeSuccess) {
+                trader.playSound(villager, Sound.ENTITY_VILLAGER_TRADE, 1, 1);
+            } else {
+                trader.playSound(villager, Sound.ENTITY_VILLAGER_NO, 1, 1);
             }
         } else if (column == 8) {
             if (row == 1) {
@@ -219,11 +221,11 @@ public class MerchantRecipesGUI implements InventoryHolder {
             return 0;
         }
 
-        if (recipeIndex < 0 || recipeIndex >= merchant.getRecipeCount()) {
+        if (recipeIndex < 0 || recipeIndex >= villager.getRecipeCount()) {
             return 0;
         }
 
-        MerchantRecipe merchantOffer = merchant.getRecipe(recipeIndex);
+        MerchantRecipe merchantOffer = villager.getRecipe(recipeIndex);
         int traded = 0;
         for (int i = merchantOffer.getUses(); i < merchantOffer.getMaxUses(); i++) {
             if (trade0(merchantOffer)) {
@@ -242,11 +244,11 @@ public class MerchantRecipesGUI implements InventoryHolder {
             return false;
         }
 
-        if (recipeIndex < 0 || recipeIndex >= merchant.getRecipeCount()) {
+        if (recipeIndex < 0 || recipeIndex >= villager.getRecipeCount()) {
             return false;
         }
 
-        if (trade0(merchant.getRecipe(recipeIndex))) {
+        if (trade0(villager.getRecipe(recipeIndex))) {
             update();
             return true;
         } else {
@@ -259,15 +261,12 @@ public class MerchantRecipesGUI implements InventoryHolder {
             return false;
         }
 
-        PlayerPurchaseEvent event;
-        if (merchant instanceof AbstractVillager abstractVillager) {
-            event = new PlayerTradeEvent(trader, abstractVillager, merchantOffer, true, true);
-        } else {
-            event = new PlayerPurchaseEvent(trader, merchantOffer, false, true);
-        }
+        PlayerPurchaseEvent event = new PlayerTradeEvent(trader, villager, merchantOffer, true, true);
+
         if (!event.callEvent()) {
             return false;
         }
+
         merchantOffer = event.getTrade();
         List<ItemStack> ingredients = new ArrayList<>(merchantOffer.getIngredients());
         if (ingredients.size() >= 1) {
@@ -307,7 +306,7 @@ public class MerchantRecipesGUI implements InventoryHolder {
             BoxUtil.getStock(trader).ifPresent(stock -> stock.increase(result.get(), resultBukkit.getAmount(), cause));
         }
 
-        NMSUtil.processTrade(trader, merchant, merchantOffer, event);
+        NMSUtil.processTrade(trader, villager, merchantOffer, event);
         return true;
     }
 
@@ -318,52 +317,26 @@ public class MerchantRecipesGUI implements InventoryHolder {
         player.getInventory().setItemInMainHand(hand);
     }
 
+    /**
+     * @deprecated use {@link #getCurrentSelectedIndices()}
+     */
+    @Deprecated(forRemoval = true)
     public int getCurrentSelected() {
-        return getTradeStickData().getOfferSelections().getOrDefault(trader.getUniqueId(), -1);
+        int[] selected = data.getSelectedIndices(trader.getUniqueId());
+        return selected.length == 0 ? -1 : selected[0];
     }
 
-    public void setCurrentSelected(int index) {
-        TradeStickData data = getTradeStickData();
-        data.getOfferSelections().put(trader.getUniqueId(), index);
-        setTradeStickData(data);
-        update();
+    public int[] getCurrentSelectedIndices() {
+        return data.getSelectedIndices(trader.getUniqueId());
     }
 
     public int getScroll() {
-        return Math.max(0, Math.min(getMaxScroll(), getTradeStickData().getScrolls().getOrDefault(trader.getUniqueId(), 0)));
+        return Math.max(0, Math.min(getMaxScroll(), data.getScroll(trader.getUniqueId())));
     }
 
     public void setScroll(int scroll) {
-        TradeStickData data = getTradeStickData();
-        data.getScrolls().put(trader.getUniqueId(), scroll);
-        setTradeStickData(data);
+        data.setScroll(trader.getUniqueId(), scroll);
+        data.saveTo(villager);
         update();
-    }
-
-    private TradeStickData getTradeStickData() {
-        if (!(merchant instanceof AbstractVillager villager)) {
-            return new TradeStickData();
-        }
-
-        if (!villager.getPersistentDataContainer().has(
-                TradeStickData.TRADE_STICK_DATA_KEY,
-                TradeStickData.TRADE_STICK_DATA_TYPE)) {
-            villager.getPersistentDataContainer().remove(TradeStickData.TRADE_STICK_DATA_KEY);
-        }
-        return villager.getPersistentDataContainer().getOrDefault(
-                TradeStickData.TRADE_STICK_DATA_KEY,
-                TradeStickData.TRADE_STICK_DATA_TYPE,
-                new TradeStickData()
-        );
-    }
-
-    private void setTradeStickData(TradeStickData tradeStickData) {
-        if (merchant instanceof AbstractVillager villager) {
-            villager.getPersistentDataContainer().set(
-                    TradeStickData.TRADE_STICK_DATA_KEY,
-                    TradeStickData.TRADE_STICK_DATA_TYPE,
-                    tradeStickData
-            );
-        }
     }
 }

--- a/src/main/java/net/okocraft/boxtradestick/MerchantRecipesGUI.java
+++ b/src/main/java/net/okocraft/boxtradestick/MerchantRecipesGUI.java
@@ -216,7 +216,7 @@ public class MerchantRecipesGUI implements InventoryHolder {
         }
     }
 
-    public boolean tradeForMaxUses(int[] recipeIndices) {
+    public int tradeForMaxUses(int[] recipeIndices) {
         List<TradeResult> results = new ArrayList<>();
         for (int index : recipeIndices) {
             TradeResult result = tradeForMaxUses(index);
@@ -227,7 +227,7 @@ public class MerchantRecipesGUI implements InventoryHolder {
         if (succeeded.length == 0) {
             trader.playSound(villager, Sound.ENTITY_VILLAGER_NO, 1, 1);
             trader.sendActionBar(Translatables.OUT_OF_STOCK);
-            return false;
+            return 0;
         }
 
         update();
@@ -236,14 +236,14 @@ public class MerchantRecipesGUI implements InventoryHolder {
         if (succeeded.length == 1) {
             TradeResult result = succeeded[0];
             trader.sendActionBar(Translatables.RESULT_TIMES.apply(result.getCount(), result.getRecipe().getResult()));
-            return true;
-        }
+        } else {
 
-        trader.sendActionBar(Translatables.MULTIPLE_RESULT_TIMES.apply(
-                succeeded.length,
-                Arrays.stream(succeeded).mapToInt(TradeResult::getCount).sum()
-        ));
-        return true;
+            trader.sendActionBar(Translatables.MULTIPLE_RESULT_TIMES.apply(
+                    succeeded.length,
+                    Arrays.stream(succeeded).mapToInt(TradeResult::getCount).sum()
+            ));
+        }
+        return succeeded.length;
     }
 
     private TradeResult tradeForMaxUses(int recipeIndex) {

--- a/src/main/java/net/okocraft/boxtradestick/MerchantRecipesGUI.java
+++ b/src/main/java/net/okocraft/boxtradestick/MerchantRecipesGUI.java
@@ -220,11 +220,12 @@ public class MerchantRecipesGUI implements InventoryHolder {
         List<TradeResult> results = new ArrayList<>();
         for (int index : recipeIndices) {
             TradeResult result = tradeForMaxUses(index);
-            results.add(result);
+            if (result.succeeded()) {
+                results.add(result);
+            }
         }
 
-        var succeeded = results.stream().filter(TradeResult::succeeded).toArray(TradeResult[]::new);
-        if (succeeded.length == 0) {
+        if (results.isEmpty()) {
             trader.playSound(villager, Sound.ENTITY_VILLAGER_NO, 1, 1);
             trader.sendActionBar(Translatables.OUT_OF_STOCK);
             return 0;
@@ -233,17 +234,17 @@ public class MerchantRecipesGUI implements InventoryHolder {
         update();
         trader.playSound(villager, Sound.ENTITY_VILLAGER_TRADE, 1, 1);
 
-        if (succeeded.length == 1) {
-            TradeResult result = succeeded[0];
+        if (results.size() == 1) {
+            TradeResult result = results.get(0);
             trader.sendActionBar(Translatables.RESULT_TIMES.apply(result.getCount(), result.getRecipe().getResult()));
         } else {
 
             trader.sendActionBar(Translatables.MULTIPLE_RESULT_TIMES.apply(
-                    Arrays.stream(succeeded).mapToInt(TradeResult::getCount).sum(),
-                    succeeded.length
+                    results.stream().mapToInt(TradeResult::getCount).sum(),
+                    results.size()
             ));
         }
-        return succeeded.length;
+        return results.size();
     }
 
     private TradeResult tradeForMaxUses(int recipeIndex) {

--- a/src/main/java/net/okocraft/boxtradestick/PlayerListener.java
+++ b/src/main/java/net/okocraft/boxtradestick/PlayerListener.java
@@ -233,7 +233,7 @@ public class PlayerListener implements Listener {
 
     private long calcCooldownTime(Player player) {
         long cooldownTime = tradeCooldownEndTimeMap.getOrDefault(player.getUniqueId(), 0L);
-        return cooldownTime -System.currentTimeMillis();
+        return cooldownTime - System.currentTimeMillis();
     }
 
     private boolean isTrading(Merchant merchant) {

--- a/src/main/java/net/okocraft/boxtradestick/PlayerListener.java
+++ b/src/main/java/net/okocraft/boxtradestick/PlayerListener.java
@@ -109,16 +109,8 @@ public class PlayerListener implements Listener {
             return;
         }
 
-        for (int index : selectedIndices) {
-            int traded = gui.tradeForMaxUses(index);
-            if (traded > 0) {
-                player.playSound(villager, Sound.ENTITY_VILLAGER_TRADE, 1, 1);
-                // NOTE: 複数回実行されるケースがあるが、上書きされるだけで最後にputされた値を使うで問題がないためそのままにする
-                hitTradeCooldown.put(player.getUniqueId(), System.currentTimeMillis());
-            } else {
-                player.playSound(villager, Sound.ENTITY_VILLAGER_NO, 1, 1);
-                player.sendActionBar(Translatables.OUT_OF_STOCK);
-            }
+        if (gui.tradeForMaxUses(selectedIndices)) {
+            hitTradeCooldown.put(player.getUniqueId(), System.currentTimeMillis());
         }
 
         NMSUtil.stopTrading(villager);

--- a/src/main/java/net/okocraft/boxtradestick/PlayerListener.java
+++ b/src/main/java/net/okocraft/boxtradestick/PlayerListener.java
@@ -79,6 +79,10 @@ public class PlayerListener implements Listener {
 
         event.setCancelled(true);
 
+        if (!MerchantRecipesGUI.canTradeByStick(villager)) {
+            return;
+        }
+
         long cooldown = hitTradeCooldown.getOrDefault(player.getUniqueId(), 0L) + 1000L - System.currentTimeMillis();
         if (0 < cooldown) {
             player.sendActionBar(Translatables.HIT_TRADING_COOLDOWN.apply(cooldown));
@@ -136,7 +140,9 @@ public class PlayerListener implements Listener {
             return;
         }
 
-        player.openInventory(new MerchantRecipesGUI(player, abstractVillager).getInventory());
+        if (MerchantRecipesGUI.canTradeByStick(abstractVillager)) {
+            player.openInventory(new MerchantRecipesGUI(player, abstractVillager).getInventory());
+        }
     }
 
     @EventHandler
@@ -212,7 +218,8 @@ public class PlayerListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onInventoryClose(InventoryCloseEvent event) {
         MerchantRecipesGUI gui = MerchantRecipesGUI.fromTopInventory(event.getView().getTopInventory());
-        if (gui != null && gui.getMerchant() instanceof AbstractVillager villager) {
+        if (gui != null) {
+            AbstractVillager villager = gui.getMerchant();
             if (ENTITY_SCHEDULER) {
                 villager.getScheduler().run(plugin, task -> NMSUtil.stopTrading(villager), null);
             } else {

--- a/src/main/java/net/okocraft/boxtradestick/TradeStickData.java
+++ b/src/main/java/net/okocraft/boxtradestick/TradeStickData.java
@@ -1,105 +1,194 @@
 package net.okocraft.boxtradestick;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.bukkit.NamespacedKey;
+import org.bukkit.entity.AbstractVillager;
 import org.bukkit.persistence.PersistentDataAdapterContext;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 
 public class TradeStickData {
-    public static final NamespacedKey TRADE_STICK_DATA_KEY =
-            Objects.requireNonNull(NamespacedKey.fromString("boxtradestick:trade_stick_data"));
+
+    private static final NamespacedKey TRADE_STICK_DATA_KEY = Objects.requireNonNull(NamespacedKey.fromString("boxtradestick:trade_stick_data"));
+    private static final PersistentDataType<PersistentDataContainer[], TradeStickData> TRADE_STICK_DATA_TYPE = new TradeStickDataType();
+
+    public static @NotNull TradeStickData loadFrom(@NotNull AbstractVillager villager) {
+        var data = villager.getPersistentDataContainer().get(TRADE_STICK_DATA_KEY, TRADE_STICK_DATA_TYPE);
+        return data != null ? data : new TradeStickData();
+    }
 
     private static final NamespacedKey ID_KEY = Objects.requireNonNull(NamespacedKey.fromString("boxtradestick:user"));
+    private static final NamespacedKey VALUE_KEY = Objects.requireNonNull(NamespacedKey.fromString("boxtradestick:value"));
+
+    /* === Backward Compatibility === */
     private static final NamespacedKey OFFER_NUMBER_KEY = Objects.requireNonNull(NamespacedKey.fromString("boxtradestick:offer_number"));
     private static final NamespacedKey SCROLL_KEY = Objects.requireNonNull(NamespacedKey.fromString("boxtradestick:scroll"));
 
-    private final Map<UUID, Integer> offerSelections = new ConcurrentHashMap<>();
-    private final Map<UUID, Integer> scrolls = new ConcurrentHashMap<>();
+    private static final int SHIFTS_FOR_SCROLL = 27;
+    private static final int MASK_TO_CLEAR_SCROLL = (1 << SHIFTS_FOR_SCROLL) - 1;
+    private static final int[] EMPTY_ARRAY = new int[0];
 
-    public TradeStickData() {
+    public static final int MAXIMUM_INDEX = SHIFTS_FOR_SCROLL - 1;
+    public static final int MAXIMUM_SCROLL = ~MASK_TO_CLEAR_SCROLL >>> SHIFTS_FOR_SCROLL;
+
+    /*
+        TradeStickData manages player's data (offer selection states and the scroll position) by int.
+
+        The upper 5 bits represent the scroll position in the GUI.
+        The other bits indicate whether the offer is selected.
+
+        | scroll |    offer selection state    |
+        |  00000 | 000000000000000000000000000 |
+     */
+    private final Object2IntMap<UUID> playerDataMap = new Object2IntOpenHashMap<>();
+
+    public boolean isSelected(@NotNull UUID uuid, int index) {
+        if (index < 0 || MAXIMUM_INDEX < index) {
+            throw new IllegalArgumentException();
+        }
+
+        int state = playerDataMap.getInt(uuid);
+        int bits = 1 << index;
+        return (state & bits) == bits;
     }
 
-    public TradeStickData(Map<UUID, Integer> offerSelections, Map<UUID, Integer> scrolls) {
-        this.offerSelections.putAll(offerSelections);
-        this.scrolls.putAll(scrolls);
+    public int[] getSelectedIndices(@NotNull UUID uuid) {
+        int state = playerDataMap.getInt(uuid);
+        int size = Integer.bitCount(state & MASK_TO_CLEAR_SCROLL);
+
+        if (size == 0) {
+            return EMPTY_ARRAY;
+        }
+
+        int[] result = new int[size];
+        int i = 0;
+
+        for (int j = 0; j <= MAXIMUM_INDEX; j++) {
+            int bits = 1 << j;
+            if ((state & bits) == bits) {
+                result[i++] = j;
+            }
+        }
+
+        return result;
     }
 
-    public Map<UUID, Integer> getOfferSelections() {
-        return this.offerSelections;
+    public void toggleOfferSelection(@NotNull UUID uuid, int index) {
+        if (index < 0 || MAXIMUM_INDEX < index) {
+            throw new IllegalArgumentException();
+        }
+
+        int state = playerDataMap.getInt(uuid);
+        int bits = 1 << index;
+        int newState = (state & bits) == bits ? state & ~bits : state | bits; // isSelected ? unselect : select
+        playerDataMap.put(uuid, newState);
     }
 
-    public Map<UUID, Integer> getScrolls() {
-        return this.scrolls;
+    public int getScroll(@NotNull UUID uuid) {
+        int state = playerDataMap.getInt(uuid);
+        return state >>> SHIFTS_FOR_SCROLL;
     }
 
-    public static final PersistentDataType<PersistentDataContainer[], TradeStickData> TRADE_STICK_DATA_TYPE =
-            new PersistentDataType<>() {
+    public void setScroll(@NotNull UUID uuid, int scroll) {
+        if (scroll < 0 || MAXIMUM_SCROLL < scroll) {
+            throw new IllegalArgumentException();
+        }
 
-                @NotNull
-                @Override
-                public Class<PersistentDataContainer[]> getPrimitiveType() {
-                    return PersistentDataContainer[].class;
+        int state = playerDataMap.getInt(uuid);
+        int newState = (state & MASK_TO_CLEAR_SCROLL) | (scroll << SHIFTS_FOR_SCROLL);
+        playerDataMap.put(uuid, newState);
+    }
+
+    @TestOnly
+    public int getBits(@NotNull UUID uuid) {
+        return playerDataMap.getInt(uuid);
+    }
+
+    public void saveTo(@NotNull AbstractVillager villager) {
+        villager.getPersistentDataContainer().set(TRADE_STICK_DATA_KEY, TRADE_STICK_DATA_TYPE, this);
+    }
+
+    private static class TradeStickDataType implements PersistentDataType<PersistentDataContainer[], TradeStickData> {
+
+        @NotNull
+        @Override
+        public Class<PersistentDataContainer[]> getPrimitiveType() {
+            return PersistentDataContainer[].class;
+        }
+
+        @NotNull
+        @Override
+        public Class<TradeStickData> getComplexType() {
+            return TradeStickData.class;
+        }
+
+        @Override
+        public PersistentDataContainer @NotNull [] toPrimitive(TradeStickData complex,
+                                                               @NotNull PersistentDataAdapterContext context) {
+            List<PersistentDataContainer> containerList = new ArrayList<>();
+
+            for (Object2IntMap.Entry<UUID> entry : complex.playerDataMap.object2IntEntrySet()) {
+                PersistentDataContainer container = context.newPersistentDataContainer();
+
+                container.set(ID_KEY, STRING, entry.getKey().toString());
+                container.set(VALUE_KEY, INTEGER, entry.getIntValue());
+
+                containerList.add(container);
+            }
+
+            return containerList.toArray(PersistentDataContainer[]::new);
+        }
+
+        @Override
+        public @NotNull TradeStickData fromPrimitive(PersistentDataContainer[] primitive,
+                                                     @NotNull PersistentDataAdapterContext context) {
+            TradeStickData data = new TradeStickData();
+
+            for (PersistentDataContainer container : primitive) {
+                UUID uuid = parseUuid(container.get(ID_KEY, STRING));
+
+                if (uuid == null) {
+                    continue;
                 }
 
-                @NotNull
-                @Override
-                public Class<TradeStickData> getComplexType() {
-                    return TradeStickData.class;
-                }
+                if (container.has(OFFER_NUMBER_KEY) || container.has(SCROLL_KEY)) {
+                    Integer offerNumber = container.get(OFFER_NUMBER_KEY, INTEGER);
 
-                @Override
-                public PersistentDataContainer @NotNull [] toPrimitive(TradeStickData complex,
-                                                                       @NotNull PersistentDataAdapterContext context) {
-                    List<PersistentDataContainer> containerList = new ArrayList<>();
-                    PersistentDataContainer container;
-
-                    Set<UUID> ids = new HashSet<>();
-                    ids.addAll(complex.offerSelections.keySet());
-                    ids.addAll(complex.scrolls.keySet());
-
-                    for (UUID id : ids) {
-                        if (id == null) {
-                            continue;
-                        }
-                        container = context.newPersistentDataContainer();
-                        container.set(ID_KEY, STRING, id.toString());
-                        container.set(OFFER_NUMBER_KEY, INTEGER, complex.offerSelections.getOrDefault(id, -1));
-                        container.set(SCROLL_KEY, INTEGER, complex.scrolls.getOrDefault(id, 0));
-                        containerList.add(container);
+                    if (offerNumber != null) {
+                        data.toggleOfferSelection(uuid, offerNumber);
                     }
 
-                    return containerList.toArray(PersistentDataContainer[]::new);
-                }
+                    Integer scroll = container.get(SCROLL_KEY, INTEGER);
 
-                @Override
-                public @NotNull TradeStickData fromPrimitive(PersistentDataContainer[] primitive,
-                                                                                @NotNull PersistentDataAdapterContext context) {
-                    Map<UUID, Integer> offerSelections = new ConcurrentHashMap<>();
-                    Map<UUID, Integer> scrolls = new ConcurrentHashMap<>();
-                    for (PersistentDataContainer container : primitive) {
-                        try {
-                            UUID id = UUID.fromString(container.getOrDefault(ID_KEY, STRING, "null"));
-                            int offerNumber = container.getOrDefault(OFFER_NUMBER_KEY, INTEGER, -1);
-                            int scroll = container.getOrDefault(SCROLL_KEY, INTEGER, 0);
-                            if (offerNumber != -1) {
-                                offerSelections.put(id, offerNumber);
-                            }
-                            if (scroll != 0) {
-                                scrolls.put(id, scroll);
-                            }
-                        } catch (IllegalArgumentException ignored) {
-                        }
+                    if (scroll != null) {
+                        data.setScroll(uuid, scroll);
                     }
-                    return new TradeStickData(offerSelections, scrolls);
+                } else {
+                    int value = container.getOrDefault(VALUE_KEY, INTEGER, 0);
+                    data.playerDataMap.put(uuid, value);
                 }
-            };
+            }
+
+            return data;
+        }
+
+        private @Nullable UUID parseUuid(@Nullable String value) {
+            if (value != null) {
+                try {
+                    return UUID.fromString(value);
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+            return null;
+        }
+    }
 }

--- a/src/main/java/net/okocraft/boxtradestick/Translatables.java
+++ b/src/main/java/net/okocraft/boxtradestick/Translatables.java
@@ -62,6 +62,10 @@ public final class Translatables {
                     Component.translatable(result)
             );
 
+    public static final DoubleArgument<Integer, Integer> MULTIPLE_RESULT_TIMES =
+            (kinds, traded) -> Component.translatable("multiple-result-times", NamedTextColor.YELLOW)
+                    .args(Component.text(kinds), Component.text(traded));
+
     public static final List<Component> GUI_RECIPE_SELECTED_LORE =
             List.of(
                     nonItalic("gui.recipe-selected-lore-1").color(NamedTextColor.GRAY),

--- a/src/main/java/net/okocraft/boxtradestick/Translatables.java
+++ b/src/main/java/net/okocraft/boxtradestick/Translatables.java
@@ -63,8 +63,8 @@ public final class Translatables {
             );
 
     public static final DoubleArgument<Integer, Integer> MULTIPLE_RESULT_TIMES =
-            (kinds, traded) -> Component.translatable("multiple-result-times", NamedTextColor.YELLOW)
-                    .args(Component.text(kinds), Component.text(traded));
+            (traded, kinds) -> Component.translatable("multiple-result-times", NamedTextColor.YELLOW)
+                    .args(Component.text(traded), Component.text(kinds));
 
     public static final List<Component> GUI_RECIPE_SELECTED_LORE =
             List.of(

--- a/src/main/resources/en.yml
+++ b/src/main/resources/en.yml
@@ -12,5 +12,5 @@ gui:
   result-name-out-of-stock: "{0} (Out of stock!)"
   result-bulk-trade: "Bulk trade {0}"
 result-times: "Traded {0} times and got {1} {2}s"
-multiple-result-times: "total of {2} traded the {1} kind of items."
+multiple-result-times: "total of {0} traded the {1} kind of items."
 hit-trading-cooldown: "Hit trading is now in cooldown for {0} second."

--- a/src/main/resources/en.yml
+++ b/src/main/resources/en.yml
@@ -12,5 +12,5 @@ gui:
   result-name-out-of-stock: "{0} (Out of stock!)"
   result-bulk-trade: "Bulk trade {0}"
 result-times: "Traded {0} times and got {1} {2}s"
-multiple-result-times: "total of {0} traded the {1} kind of items."
+multiple-result-times: "Total of {0} traded the {1} kind of items."
 hit-trading-cooldown: "Hit trading is now in cooldown for {0} second."

--- a/src/main/resources/en.yml
+++ b/src/main/resources/en.yml
@@ -12,4 +12,5 @@ gui:
   result-name-out-of-stock: "{0} (Out of stock!)"
   result-bulk-trade: "Bulk trade {0}"
 result-times: "Traded {0} times and got {1} {2}s"
+multiple-result-times: "total of {2} traded the {1} kind of items."
 hit-trading-cooldown: "Hit trading is now in cooldown for {0} second."

--- a/src/main/resources/ja_JP.yml
+++ b/src/main/resources/ja_JP.yml
@@ -12,5 +12,5 @@ gui:
   result-name-out-of-stock: "{0} (売り切れ！)"
   result-bulk-trade: "{0}を一括取引"
 result-times: "{0}回交易し、{2}を{1}個手に入れました。"
-multiple-result-times: "{0}種類のアイテムを合計{1}回交易しました。"
+multiple-result-times: "{1}種類のアイテムを合計{0}回交易しました。"
 hit-trading-cooldown: "殴り交易はクールダウン中です。(あと{0}秒)"

--- a/src/main/resources/ja_JP.yml
+++ b/src/main/resources/ja_JP.yml
@@ -12,4 +12,5 @@ gui:
   result-name-out-of-stock: "{0} (売り切れ！)"
   result-bulk-trade: "{0}を一括取引"
 result-times: "{0}回交易し、{2}を{1}個手に入れました。"
+multiple-result-times: "{0}種類のアイテムを合計{1}回交易しました。"
 hit-trading-cooldown: "殴り交易はクールダウン中です。(あと{0}秒)"

--- a/src/test/java/net/okocraft/boxtradestick/TradeStickDataTest.java
+++ b/src/test/java/net/okocraft/boxtradestick/TradeStickDataTest.java
@@ -1,0 +1,61 @@
+package net.okocraft.boxtradestick;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+class TradeStickDataTest {
+
+    private final TradeStickData tradeStickData = new TradeStickData();
+
+    @Test
+    void testToggleOfferSelection() {
+        UUID uuid = UUID.randomUUID();
+
+        Assertions.assertFalse(tradeStickData.isSelected(uuid, 0));
+        Assertions.assertFalse(tradeStickData.isSelected(uuid, 1));
+
+        tradeStickData.toggleOfferSelection(uuid, 1);
+
+        Assertions.assertFalse(tradeStickData.isSelected(uuid, 0));
+        Assertions.assertTrue(tradeStickData.isSelected(uuid, 1));
+        Assertions.assertArrayEquals(new int[]{1}, tradeStickData.getSelectedIndices(uuid));
+    }
+
+    @Test
+    void testScroll() {
+        UUID uuid = UUID.randomUUID();
+
+        Assertions.assertEquals(0, tradeStickData.getScroll(uuid));
+        tradeStickData.setScroll(uuid, 5);
+        Assertions.assertEquals(5, tradeStickData.getScroll(uuid));
+
+        tradeStickData.setScroll(uuid, TradeStickData.MAXIMUM_SCROLL);
+        Assertions.assertEquals(TradeStickData.MAXIMUM_SCROLL, tradeStickData.getScroll(uuid));
+    }
+
+    @Test
+    void testBitState() {
+        UUID uuid = UUID.randomUUID();
+
+        tradeStickData.toggleOfferSelection(uuid, 1);
+        tradeStickData.toggleOfferSelection(uuid, 5);
+        tradeStickData.toggleOfferSelection(uuid, 10);
+        Assertions.assertEquals(0b00000000000000000000010000100010, tradeStickData.getBits(uuid));
+
+        tradeStickData.toggleOfferSelection(uuid, 26);
+        Assertions.assertEquals(0b00000100000000000000010000100010, tradeStickData.getBits(uuid));
+
+        tradeStickData.setScroll(uuid, 5);
+        Assertions.assertEquals(0b00101100000000000000010000100010, tradeStickData.getBits(uuid));
+
+        tradeStickData.toggleOfferSelection(uuid, 15);
+        Assertions.assertEquals(0b00101100000000001000010000100010, tradeStickData.getBits(uuid));
+
+        tradeStickData.setScroll(uuid, TradeStickData.MAXIMUM_SCROLL);
+        Assertions.assertEquals(0b11111100000000001000010000100010, tradeStickData.getBits(uuid));
+
+        Assertions.assertArrayEquals(new int[]{1, 5, 10, 15, 26}, tradeStickData.getSelectedIndices(uuid));
+    }
+}


### PR DESCRIPTION
### 概要
現状のBoxTradeStickでは1つの取引内容を選択することで、それをBoxStickによる殴りでトレードできるような実装内容になっていました
今回のPRでは複数の取引内容を選択して一括して取引できるように拡張しました

※まだ動作確認してないです。実装の基本方針は変わらないと思うのでレビューしてもらって問題有りません！

### TODOリスト
- [x] 複数選択の実装
- [x] 既存の保存されている単独選択の内容を複数選択に引き継ぐ
- [ ] 動作確認