### PR TITLE
Safer Villager Handling

### DIFF
--- a/src/main/java/net/okocraft/boxtradestick/BoxTradeStickPlugin.java
+++ b/src/main/java/net/okocraft/boxtradestick/BoxTradeStickPlugin.java
@@ -79,7 +79,7 @@ public final class BoxTradeStickPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
+        getServer().getPluginManager().registerEvents(new PlayerListener(), this);
     }
 
     @Override

--- a/src/main/java/net/okocraft/boxtradestick/TradeProcessor.java
+++ b/src/main/java/net/okocraft/boxtradestick/TradeProcessor.java
@@ -1,0 +1,165 @@
+package net.okocraft.boxtradestick;
+
+import io.papermc.paper.event.player.PlayerPurchaseEvent;
+import io.papermc.paper.event.player.PlayerTradeEvent;
+import java.util.ArrayList;
+import java.util.List;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import net.okocraft.box.api.model.item.BoxItem;
+import net.okocraft.box.api.transaction.InventoryTransaction;
+import net.okocraft.box.api.transaction.TransactionResult;
+import net.okocraft.box.storage.api.factory.item.BoxItemFactory;
+import org.bukkit.Sound;
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MerchantRecipe;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class TradeProcessor {
+
+    public static boolean canTradeByStick(@NotNull AbstractVillager villager) {
+        return villager.getRecipeCount() < TradeStickData.MAXIMUM_INDEX;
+    }
+
+    public static int processSelectedOffersForMaxUses(@NotNull Player trader, @NotNull AbstractVillager villager) {
+        int[] recipeIndices = TradeStickData.loadFrom(villager).getSelectedIndices(trader.getUniqueId());
+
+        if (recipeIndices.length == 0) {
+            trader.playSound(villager, Sound.ENTITY_VILLAGER_NO, 1, 1);
+            return 0;
+        }
+
+        List<TradeResult> results = new ArrayList<>(recipeIndices.length);
+
+        for (int index : recipeIndices) {
+            TradeResult result = tradeForMaxUses(trader, villager, index);
+            if (result != null) {
+                results.add(result);
+            }
+        }
+
+        if (results.isEmpty()) {
+            trader.playSound(villager, Sound.ENTITY_VILLAGER_NO, 1, 1);
+            trader.sendActionBar(Translatables.OUT_OF_STOCK);
+            return 0;
+        }
+
+        trader.playSound(villager, Sound.ENTITY_VILLAGER_TRADE, 1, 1);
+
+        if (results.size() == 1) {
+            TradeResult result = results.get(0);
+            trader.sendActionBar(Translatables.RESULT_TIMES.apply(result.count, result.recipe.getResult()));
+        } else {
+            trader.sendActionBar(Translatables.MULTIPLE_RESULT_TIMES.apply(
+                    results.stream().mapToInt(TradeResult::count).sum(),
+                    results.size()
+            ));
+        }
+
+        return results.size();
+    }
+
+    public static @Nullable TradeResult tradeForMaxUses(@NotNull Player trader, @NotNull AbstractVillager villager, int recipeIndex) {
+        if (!BoxUtil.checkPlayerCondition(trader, "boxtradestick.trade")) {
+            return null;
+        }
+
+        if (recipeIndex < 0 || recipeIndex >= villager.getRecipeCount()) {
+            return null;
+        }
+
+        MerchantRecipe merchantOffer = villager.getRecipe(recipeIndex);
+        int traded = 0;
+
+        for (int i = merchantOffer.getUses(); i < merchantOffer.getMaxUses(); i++) {
+            if (trade0(trader, villager, recipeIndex)) {
+                traded++;
+            }
+        }
+
+        return traded > 0 ? new TradeResult(traded, merchantOffer) : null;
+    }
+
+    public static boolean trade(@NotNull Player trader, @NotNull AbstractVillager villager, int recipeIndex) {
+        if (!BoxUtil.checkPlayerCondition(trader, "boxtradestick.trade")) {
+            return false;
+        }
+
+        if (recipeIndex < 0 || recipeIndex >= villager.getRecipeCount()) {
+            return false;
+        }
+
+        return trade0(trader, villager, recipeIndex);
+    }
+
+    private static boolean trade0(@NotNull Player trader, @NotNull AbstractVillager villager, int recipeIndex) {
+        var merchantOffer = villager.getRecipe(recipeIndex);
+
+        if (merchantOffer.getUses() >= merchantOffer.getMaxUses()) {
+            return false;
+        }
+
+        PlayerPurchaseEvent event = new PlayerTradeEvent(trader, villager, merchantOffer, true, true);
+
+        if (!event.callEvent()) {
+            return false;
+        }
+
+        merchantOffer = event.getTrade();
+        List<ItemStack> ingredients = new ArrayList<>(merchantOffer.getIngredients());
+        if (ingredients.size() >= 1) {
+            ingredients.set(0, merchantOffer.getAdjustedIngredient1());
+        }
+        var cause = new BoxUtil.Trade(trader, merchantOffer);
+        if (!BoxUtil.tryConsumingStockMulti(trader, ingredients, cause)) {
+            return false;
+        }
+
+        var resultBukkit = merchantOffer.getResult();
+
+        var result = BoxUtil.getBoxItem(resultBukkit);
+        if (result.isEmpty()) {
+            // painful api usage!
+            BoxItem resultBoxItem = BoxItemFactory.createCustomItem(
+                    resultBukkit.clone(),
+                    PlainTextComponentSerializer.plainText().serialize(resultBukkit.displayName()),
+                    -1
+            );
+            TransactionResult transaction = InventoryTransaction.withdraw(
+                    trader.getInventory(),
+                    resultBoxItem,
+                    resultBukkit.getAmount()
+            );
+            ItemStack drop = resultBukkit.clone();
+            if (transaction.getType().isModified()) {
+                if (drop.getAmount() != transaction.getAmount()) {
+                    drop.setAmount(drop.getAmount() - transaction.getAmount());
+                    drop(trader, drop);
+                }
+            } else {
+                drop(trader, drop);
+            }
+        } else {
+            // stock is definitely present.
+            BoxUtil.getStock(trader).ifPresent(stock -> stock.increase(result.get(), resultBukkit.getAmount(), cause));
+        }
+
+        NMSUtil.processTrade(trader, villager, merchantOffer, event);
+        return true;
+    }
+
+    private static void drop(Player player, ItemStack item) {
+        ItemStack hand = player.getInventory().getItemInMainHand().clone();
+        player.getInventory().setItemInMainHand(item);
+        player.dropItem(true);
+        player.getInventory().setItemInMainHand(hand);
+    }
+
+    private TradeProcessor() {
+    }
+
+    public record TradeResult(int count, @NotNull MerchantRecipe recipe) {
+    }
+}

--- a/src/main/java/net/okocraft/boxtradestick/TradeStickData.java
+++ b/src/main/java/net/okocraft/boxtradestick/TradeStickData.java
@@ -22,6 +22,11 @@ public class TradeStickData {
 
     public static @NotNull TradeStickData loadFrom(@NotNull AbstractVillager villager) {
         var data = villager.getPersistentDataContainer().get(TRADE_STICK_DATA_KEY, TRADE_STICK_DATA_TYPE);
+
+        if (data != null && data.needUpdateVillager) {
+            data.saveTo(villager);
+        }
+
         return data != null ? data : new TradeStickData();
     }
 
@@ -32,7 +37,7 @@ public class TradeStickData {
     private static final NamespacedKey OFFER_NUMBER_KEY = Objects.requireNonNull(NamespacedKey.fromString("boxtradestick:offer_number"));
     private static final NamespacedKey SCROLL_KEY = Objects.requireNonNull(NamespacedKey.fromString("boxtradestick:scroll"));
 
-    private static final int SHIFTS_FOR_SCROLL = 27;
+    private static final int SHIFTS_FOR_SCROLL = Integer.SIZE - 5;
     private static final int MASK_TO_CLEAR_SCROLL = (1 << SHIFTS_FOR_SCROLL) - 1;
     private static final int[] EMPTY_ARRAY = new int[0];
 
@@ -50,9 +55,17 @@ public class TradeStickData {
      */
     private final Object2IntMap<UUID> playerDataMap = new Object2IntOpenHashMap<>();
 
+    /*
+      This boolean value indicates whether the villager's data needs to be updated after data is loaded from the villager.
+
+      This value will be true when data is loaded with legacy data that contains OFFER_NUMBER_KEY or SCROLL_KEY.
+      When this value is true, the loadFrom method performs a save operation immediately after loading.
+     */
+    private boolean needUpdateVillager;
+
     public boolean isSelected(@NotNull UUID uuid, int index) {
         if (index < 0 || MAXIMUM_INDEX < index) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("index must be between 0 and " + MAXIMUM_INDEX + " (inclusive), but got " + index);
         }
 
         int state = playerDataMap.getInt(uuid);
@@ -83,7 +96,7 @@ public class TradeStickData {
 
     public void toggleOfferSelection(@NotNull UUID uuid, int index) {
         if (index < 0 || MAXIMUM_INDEX < index) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("index must be between 0 and " + MAXIMUM_INDEX + " (inclusive), but got " + index);
         }
 
         int state = playerDataMap.getInt(uuid);
@@ -99,7 +112,7 @@ public class TradeStickData {
 
     public void setScroll(@NotNull UUID uuid, int scroll) {
         if (scroll < 0 || MAXIMUM_SCROLL < scroll) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("scroll must be between 0 and " + MAXIMUM_SCROLL + " (inclusive), but got " + scroll);
         }
 
         int state = playerDataMap.getInt(uuid);
@@ -136,10 +149,16 @@ public class TradeStickData {
             List<PersistentDataContainer> containerList = new ArrayList<>();
 
             for (Object2IntMap.Entry<UUID> entry : complex.playerDataMap.object2IntEntrySet()) {
+                int value = entry.getIntValue();
+
+                if (value == 0) {
+                    continue;
+                }
+
                 PersistentDataContainer container = context.newPersistentDataContainer();
 
                 container.set(ID_KEY, STRING, entry.getKey().toString());
-                container.set(VALUE_KEY, INTEGER, entry.getIntValue());
+                container.set(VALUE_KEY, INTEGER, value);
 
                 containerList.add(container);
             }
@@ -160,20 +179,24 @@ public class TradeStickData {
                 }
 
                 if (container.has(OFFER_NUMBER_KEY) || container.has(SCROLL_KEY)) {
-                    Integer offerNumber = container.get(OFFER_NUMBER_KEY, INTEGER);
+                    int offerNumber = container.getOrDefault(OFFER_NUMBER_KEY, INTEGER, -1);
 
-                    if (offerNumber != null) {
+                    if (0 <= offerNumber && offerNumber <= MAXIMUM_INDEX) {
                         data.toggleOfferSelection(uuid, offerNumber);
                     }
 
-                    Integer scroll = container.get(SCROLL_KEY, INTEGER);
+                    int scroll = container.getOrDefault(SCROLL_KEY, INTEGER, 0);
 
-                    if (scroll != null) {
+                    if (0 < scroll && scroll <= MAXIMUM_SCROLL) {
                         data.setScroll(uuid, scroll);
                     }
+
+                    data.needUpdateVillager = true;
                 } else {
                     int value = container.getOrDefault(VALUE_KEY, INTEGER, 0);
-                    data.playerDataMap.put(uuid, value);
+                    if (value != 0) {
+                        data.playerDataMap.put(uuid, value);
+                    }
                 }
             }
 

--- a/src/main/java/net/okocraft/boxtradestick/TradeStickData.java
+++ b/src/main/java/net/okocraft/boxtradestick/TradeStickData.java
@@ -2,6 +2,10 @@ package net.okocraft.boxtradestick;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.AbstractVillager;
 import org.bukkit.persistence.PersistentDataAdapterContext;
@@ -10,11 +14,6 @@ import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
 
 public class TradeStickData {
 


### PR DESCRIPTION
Folia ではワールドにアクセスする時にスレッドチェックが行われ、しばしばそれに引っかかり例外が発生します。現在の `master` ブランチでも、潜在的に例外が発生し得る場所がいくつかあります。

例外を回避することが主な目的ですが、#3 を実装するに当たってリファクタリングの必要性が生じたことから、この PR でそれも同時に行いました。

まず、取引処理と GUI を完全に分離します。これにより、殴り取引時に GUI の作成処理をせずに済みます。分離後、取引処理は `TradeProcessor` クラスに移動しました。

また、GUI は `AbstractVillager` を直接保持しなくなりました。代わりにワールドの UID とエンティティの UUID を保持し、必要なときに取得します (`MerchantRecipesGUI#getVillager`)。取得後、現在のスレッドが適切かどうかチェックします。村人が見つからなかったり、スレッドが適切でない場合は `null` を返します。クリック時に `#getVillager` が `null` を返したときはインベントリを閉じます。

Folia ではテレポートイベントなど一部のイベントが呼び出されません。代わりに、GUI を開いている間、取引できるかどうかを毎 tick チェックします。これにより、エンティティの動きに関するイベントのリスナーメソッドが不要となったためを削除しました。

```java
if (!isTrading(villager)) {
    NMSUtil.stopTrading(villager);
}
```

上記のコードは、`Villager#getTrader` をリセットするために存在するようです。将来コードを読む人が理解しやすいよう、`checkCurrentTrader` に移動し、呼び出すタイミングも `simulateMobInteract` の直前にしました。`simulateMobInteract` は、放浪商人に対してもバニラと同じ処理を行うようになりました。